### PR TITLE
Add chapter titles to TOC

### DIFF
--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -23,133 +23,133 @@
 					<a href="text/halftitlepage.xhtml">The Adventures of Huckleberry Finn</a>
 					<ol>
 						<li>
-							<a href="text/chapter-1.xhtml" epub:type="z3998:roman">I</a>
+							<a href="text/chapter-1.xhtml" epub:type="z3998:roman">I. Civilizing Huck.—Miss Watson.—Tom Sawyer Waits.</a>
 						</li>
 						<li>
-							<a href="text/chapter-2.xhtml" epub:type="z3998:roman">II</a>
+							<a href="text/chapter-2.xhtml" epub:type="z3998:roman">II. The Boys Escape Jim.—Torn Sawyer’s Gang.—Deep-laid Plans.</a>
 						</li>
 						<li>
-							<a href="text/chapter-3.xhtml" epub:type="z3998:roman">III</a>
+							<a href="text/chapter-3.xhtml" epub:type="z3998:roman">III. A Good Going-over.—Grace Triumphant.—“One of Tom Sawyers’s Lies”.</a>
 						</li>
 						<li>
-							<a href="text/chapter-4.xhtml" epub:type="z3998:roman">IV</a>
+							<a href="text/chapter-4.xhtml" epub:type="z3998:roman">IV. Huck and the Judge.—Superstition.</a>
 						</li>
 						<li>
-							<a href="text/chapter-5.xhtml" epub:type="z3998:roman">V</a>
+							<a href="text/chapter-5.xhtml" epub:type="z3998:roman">V. Huck’s Father.—The Fond Parent.—Reform.</a>
 						</li>
 						<li>
-							<a href="text/chapter-6.xhtml" epub:type="z3998:roman">VI</a>
+							<a href="text/chapter-6.xhtml" epub:type="z3998:roman">VI. He Went for Judge Thatcher.—Huck Decided to Leave.—Political Economy.—Thrashing Around.</a>
 						</li>
 						<li>
-							<a href="text/chapter-7.xhtml" epub:type="z3998:roman">VII</a>
+							<a href="text/chapter-7.xhtml" epub:type="z3998:roman">VII. Laying for Him.—Locked in the Cabin.—Sinking the Body.—Resting.</a>
 						</li>
 						<li>
-							<a href="text/chapter-8.xhtml" epub:type="z3998:roman">VIII</a>
+							<a href="text/chapter-8.xhtml" epub:type="z3998:roman">VIII. Sleeping in the Woods.—Raising the Dead.—Exploring the Island.—Finding Jim.—Jim’s Escape.—Signs.—Balum.</a>
 						</li>
 						<li>
-							<a href="text/chapter-9.xhtml" epub:type="z3998:roman">IX</a>
+							<a href="text/chapter-9.xhtml" epub:type="z3998:roman">IX. The Cave.—The Floating House.</a>
 						</li>
 						<li>
-							<a href="text/chapter-10.xhtml" epub:type="z3998:roman">X</a>
+							<a href="text/chapter-10.xhtml" epub:type="z3998:roman">X. The Find.—Old Hank Bunker.—In Disguise.</a>
 						</li>
 						<li>
-							<a href="text/chapter-11.xhtml" epub:type="z3998:roman">XI</a>
+							<a href="text/chapter-11.xhtml" epub:type="z3998:roman">XI. Huck and the Woman.—The Search.—Prevarication.—Going to Goshen.</a>
 						</li>
 						<li>
-							<a href="text/chapter-12.xhtml" epub:type="z3998:roman">XII</a>
+							<a href="text/chapter-12.xhtml" epub:type="z3998:roman">XII. Slow Navigation.—Borrowing Things.—Boarding the Wreck.—The Plotters.—Hunting for the Boat.</a>
 						</li>
 						<li>
-							<a href="text/chapter-13.xhtml" epub:type="z3998:roman">XIII</a>
+							<a href="text/chapter-13.xhtml" epub:type="z3998:roman">XIII. Escaping from the Wreck.—The Watchman.—Sinking.</a>
 						</li>
 						<li>
-							<a href="text/chapter-14.xhtml" epub:type="z3998:roman">XIV</a>
+							<a href="text/chapter-14.xhtml" epub:type="z3998:roman">XIV. A General Good Time.—The Harem.—French.</a>
 						</li>
 						<li>
-							<a href="text/chapter-15.xhtml" epub:type="z3998:roman">XV</a>
+							<a href="text/chapter-15.xhtml" epub:type="z3998:roman">XV. Huck Loses the Raft.—In the Fog.—Huck Finds the Raft.—Trash.</a>
 						</li>
 						<li>
-							<a href="text/chapter-16.xhtml" epub:type="z3998:roman">XVI</a>
+							<a href="text/chapter-16.xhtml" epub:type="z3998:roman">XVI. Expectation.—A White Lie.—Floating Currency.—Running by Cairo.—Swimming Ashore.</a>
 						</li>
 						<li>
-							<a href="text/chapter-17.xhtml" epub:type="z3998:roman">XVII</a>
+							<a href="text/chapter-17.xhtml" epub:type="z3998:roman">XVII. An Evening Call.—The Farm in Arkansaw.—Interior Decorations.—Stephen Dowling Bots.—Poetical Effusions.</a>
 						</li>
 						<li>
-							<a href="text/chapter-18.xhtml" epub:type="z3998:roman">XVIII</a>
+							<a href="text/chapter-18.xhtml" epub:type="z3998:roman">XVIII. Col. Grangerford.—Aristocracy.—Feuds.—The Testament.—Recovering the Raft.—The Wood—pile.—Pork and Cabbage.</a>
 						</li>
 						<li>
-							<a href="text/chapter-19.xhtml" epub:type="z3998:roman">XIX</a>
+							<a href="text/chapter-19.xhtml" epub:type="z3998:roman">XIX. Tying Up Day—times.—An Astronomical Theory.—Running a Temperance Revival.—The Duke of Bridgewater.—The Troubles of Royalty.</a>
 						</li>
 						<li>
-							<a href="text/chapter-20.xhtml" epub:type="z3998:roman">XX</a>
+							<a href="text/chapter-20.xhtml" epub:type="z3998:roman">XX. Huck Explains.—Laying Out a Campaign.—Working the Camp—meeting.—A Pirate at the Camp—meeting.—The Duke as a Printer.</a>
 						</li>
 						<li>
-							<a href="text/chapter-21.xhtml" epub:type="z3998:roman">XXI</a>
+							<a href="text/chapter-21.xhtml" epub:type="z3998:roman">XXI. Sword Exercise.—Hamlet’s Soliloquy.—They Loafed Around Town.—A Lazy Town.—Old Boggs.—Dead.</a>
 						</li>
 						<li>
-							<a href="text/chapter-22.xhtml" epub:type="z3998:roman">XXII</a>
+							<a href="text/chapter-22.xhtml" epub:type="z3998:roman">XXII. Sherburn.—Attending the Circus.—Intoxication in the Ring.—The Thrilling Tragedy.</a>
 						</li>
 						<li>
-							<a href="text/chapter-23.xhtml" epub:type="z3998:roman">XXIII</a>
+							<a href="text/chapter-23.xhtml" epub:type="z3998:roman">XXIII. Sold.—Royal Comparisons.—Jim Gets Home-sick.</a>
 						</li>
 						<li>
-							<a href="text/chapter-24.xhtml" epub:type="z3998:roman">XXIV</a>
+							<a href="text/chapter-24.xhtml" epub:type="z3998:roman">XXIV. Jim in Royal Robes.—They Take a Passenger.—Getting Information.—Family Grief.</a>
 						</li>
 						<li>
-							<a href="text/chapter-25.xhtml" epub:type="z3998:roman">XXV</a>
+							<a href="text/chapter-25.xhtml" epub:type="z3998:roman">XXV. Is It Them?—Singing the “Doxologer.”—Awful Square—Funeral Orgies.—A Bad Investment.</a>
 						</li>
 						<li>
-							<a href="text/chapter-26.xhtml" epub:type="z3998:roman">XXVI</a>
+							<a href="text/chapter-26.xhtml" epub:type="z3998:roman">XXVI. A Pious King.—The King’s Clergy.—She Asked His Pardon.—Hiding in the Room.—Huck Takes the Money.</a>
 						</li>
 						<li>
-							<a href="text/chapter-27.xhtml" epub:type="z3998:roman">XXVII</a>
+							<a href="text/chapter-27.xhtml" epub:type="z3998:roman">XXVII. The Funeral.—Satisfying Curiosity.—Suspicious of Huck,—Quick Sales and Small.</a>
 						</li>
 						<li>
-							<a href="text/chapter-28.xhtml" epub:type="z3998:roman">XXVIII</a>
+							<a href="text/chapter-28.xhtml" epub:type="z3998:roman">XXVIII. The Trip to England.—“The Brute!”—Mary Jane Decides to Leave.—Huck Parting with Mary Jane.—Mumps.—The Opposition Line.</a>
 						</li>
 						<li>
-							<a href="text/chapter-29.xhtml" epub:type="z3998:roman">XXIX</a>
+							<a href="text/chapter-29.xhtml" epub:type="z3998:roman">XXIX. Contested Relationship.—The King Explains the Loss.—A Question of Handwriting.—Digging up the Corpse.—Huck Escapes.</a>
 						</li>
 						<li>
-							<a href="text/chapter-30.xhtml" epub:type="z3998:roman">XXX</a>
+							<a href="text/chapter-30.xhtml" epub:type="z3998:roman">XXX. The King Went for Him.—A Royal Row.—Powerful Mellow.</a>
 						</li>
 						<li>
-							<a href="text/chapter-31.xhtml" epub:type="z3998:roman">XXXI</a>
+							<a href="text/chapter-31.xhtml" epub:type="z3998:roman">XXXI. Ominous Plans.—News from Jim.—Old Recollections.—A Sheep Story.—Valuable Information.</a>
 						</li>
 						<li>
-							<a href="text/chapter-32.xhtml" epub:type="z3998:roman">XXXII</a>
+							<a href="text/chapter-32.xhtml" epub:type="z3998:roman">XXXII. Still and Sunday—like.—Mistaken Identity.—Up a Stump.—In a Dilemma.</a>
 						</li>
 						<li>
-							<a href="text/chapter-33.xhtml" epub:type="z3998:roman">XXXIII</a>
+							<a href="text/chapter-33.xhtml" epub:type="z3998:roman">XXXIII. A Nigger Stealer.—Southern Hospitality.—A Pretty Long Blessing.—Tar and Feathers.</a>
 						</li>
 						<li>
-							<a href="text/chapter-34.xhtml" epub:type="z3998:roman">XXXIV</a>
+							<a href="text/chapter-34.xhtml" epub:type="z3998:roman">XXXIV. The Hut by the Ash Hopper.—Outrageous.—Climbing the Lightning Rod.—Troubled with Witches.</a>
 						</li>
 						<li>
-							<a href="text/chapter-35.xhtml" epub:type="z3998:roman">XXXV</a>
+							<a href="text/chapter-35.xhtml" epub:type="z3998:roman">XXXV. Escaping Properly.—Dark Schemes.—Discrimination in Stealing.—A Deep Hole.</a>
 						</li>
 						<li>
-							<a href="text/chapter-36.xhtml" epub:type="z3998:roman">XXXVI</a>
+							<a href="text/chapter-36.xhtml" epub:type="z3998:roman">XXXVI. The Lightning Rod.—His Level Best.—A Bequest to Posterity.—A High Figure.</a>
 						</li>
 						<li>
-							<a href="text/chapter-37.xhtml" epub:type="z3998:roman">XXXVII</a>
+							<a href="text/chapter-37.xhtml" epub:type="z3998:roman">XXXVII. The Last Shirt.—Mooning Around.—Sailing Orders.—The Witch Pie.</a>
 						</li>
 						<li>
-							<a href="text/chapter-38.xhtml" epub:type="z3998:roman">XXXVIII</a>
+							<a href="text/chapter-38.xhtml" epub:type="z3998:roman">XXXVIII. The Coat of Arms.—A Skilled Superintendent.—Unpleasant Glory.—A Tearful Subject.</a>
 						</li>
 						<li>
-							<a href="text/chapter-39.xhtml" epub:type="z3998:roman">XXXIX</a>
+							<a href="text/chapter-39.xhtml" epub:type="z3998:roman">XXXIX. Rats.—Lively Bed—fellows.—The Straw Dummy.</a>
 						</li>
 						<li>
-							<a href="text/chapter-40.xhtml" epub:type="z3998:roman">XL</a>
+							<a href="text/chapter-40.xhtml" epub:type="z3998:roman">XL. Fishing.—The Vigilance Committee.—A Lively Run.—Jim Advises a Doctor.</a>
 						</li>
 						<li>
-							<a href="text/chapter-41.xhtml" epub:type="z3998:roman">XLI</a>
+							<a href="text/chapter-41.xhtml" epub:type="z3998:roman">XLI. The Doctor.—Uncle Silas.—Sister Hotchkiss.—Aunt Sally in Trouble.</a>
 						</li>
 						<li>
-							<a href="text/chapter-42.xhtml" epub:type="z3998:roman">XLII</a>
+							<a href="text/chapter-42.xhtml" epub:type="z3998:roman">XLII. Tom Sawyer Wounded.—The Doctor’s Story.—Tom Confesses.—Aunt Polly Arrives.—Hand Out Them Letters.</a>
 						</li>
 						<li>
-							<a href="text/chapter-43.xhtml">Chapter the Last</a>
+							<a href="text/chapter-43.xhtml">Chapter the Last. Out of Bondage.—Paying the Captive.—Yours Truly, Huck Finn.</a>
 						</li>
 					</ol>
 				</li>


### PR DESCRIPTION
In many versions, each chapter has a title of sort, at least in the table of contents. E.g. "CHAPTER I. Civilizing Huck.—Miss Watson.—Tom Sawyer Waits."

The titles added are based on Project Gutenberg's [plain text ](https://www.gutenberg.org/cache/epub/76/pg76.txt) version (they are not present in the epub version).

I feel they'd be helpful in the individual chapters as well, but they do not seem to be present in the older published versions on internet archive, so I leave them as-is for now.

